### PR TITLE
support one btcd peer connection

### DIFF
--- a/api/v1alpha1/bitcoinnode_types.go
+++ b/api/v1alpha1/bitcoinnode_types.go
@@ -33,8 +33,19 @@ type BitcoinNodeSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	RPCServer     RPCServer `json:"rpcServer,omitempty"`
 	MiningAddress string    `json:"miningAddress,omitempty"`
-	MinBlocks     int64     `json:"minBlocks,omitempty"`
-	MiningEnabled bool      `json:"miningEnabled,omitempty"`
+
+	// Host and port of peer to connect
+	// +optional
+	Peer string `json:"peer,omitempty"`
+
+	// Minimum number of blocks to mine on initial startup
+	// +optional
+	// +kubebuilder:default:=0
+	MinBlocks int64 `json:"minBlocks,omitempty"`
+
+	// CPU Mining Enabled
+	// +kubebuilder:default:=false
+	MiningEnabled bool `json:"miningEnabled,omitempty"`
 
 	// The compute resource requirements.
 	// +optional

--- a/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
+++ b/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
@@ -37,12 +37,19 @@ spec:
             description: BitcoinNodeSpec defines the desired state of BitcoinNode
             properties:
               minBlocks:
+                default: 0
+                description: Minimum number of blocks to mine on initial startup
                 format: int64
                 type: integer
               miningAddress:
                 type: string
               miningEnabled:
+                default: false
+                description: CPU Mining Enabled
                 type: boolean
+              peer:
+                description: Host and port of peer to connect
+                type: string
               resources:
                 default:
                   limits:

--- a/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
+++ b/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
@@ -3,8 +3,8 @@ kind: BitcoinNode
 metadata:
   name: btcd
 spec:
+  miningEnabled: true
   miningAddress: rhLmdkndRELHhHAUnSut5PhFZ8do8aNMk4
-  minBlocks: 400
   rpcServer:
     certSecret: btcd-rpc-tls
     user: node-user

--- a/controllers/bitcoinnode_controller.go
+++ b/controllers/bitcoinnode_controller.go
@@ -159,6 +159,19 @@ func (r *BitcoinNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	log.Info("Retreived block count", "count", blockCount)
+
+	peer := bitcoinNode.Spec.Peer
+
+	if peer != "" {
+		perm := "perm"
+		err := btcdClient.Node("connect", peer, &perm)
+		if err != nil {
+			log.Info("Failed to add peer", "error", err.Error())
+			return ctrl.Result{}, err
+		}
+		log.Info("Connected to peer", "peer", peer)
+	}
+
 	minBlocks := bitcoinNode.Spec.MinBlocks
 
 	if minBlocks != 0 && blockCount < minBlocks {


### PR DESCRIPTION
This won't be the final state of btcd peer configuration, but at least it will support one peer connection, which is enough to start mining on the simnet.