### PR TITLE
Convert RPC credentials to secret references

### DIFF
--- a/api/v1alpha1/bitcoinnode_types.go
+++ b/api/v1alpha1/bitcoinnode_types.go
@@ -25,11 +25,14 @@ type RPCServer struct {
 	// Name of the secret that contains TLS certificates for the RPC server
 	CertSecret string `json:"certSecret,omitempty"`
 
-	// Username to authenticate to the RPC server
-	User string `json:"user,omitempty"`
+	// Name of the secret that contains RPC API credentials
+	ApiAuthSecretName string `json:"apiAuthSecretName,omiteempty"`
 
-	// Password to authenticate to the RPC server
-	Password string `json:"password,omitempty"`
+	// Name of the secret key that contains RPC API username
+	ApiUserSecretKey string `json:"apiUserSecretKey,omitempty"`
+
+	// Name of the secret key that contains RPC API password
+	ApiPasswordSecretKey string `json:"apiPasswordSecretKey,omitempty"`
 }
 
 type RewardAddress struct {

--- a/api/v1alpha1/lightningnode_types.go
+++ b/api/v1alpha1/lightningnode_types.go
@@ -31,11 +31,14 @@ type BitcoinConnection struct {
 	// Name of the secret that contains TLS certificates for the RPC server
 	CertSecret string `json:"certSecret,omitempty"`
 
-	// Username to authenticate to the RPC server
-	User string `json:"user,omitempty"`
+	// Name of the secret that contains bitcoin node RPC API credentials
+	ApiAuthSecretName string `json:"apiAuthSecretName,omiteempty"`
 
-	// Password to authenticate to the RPC server
-	Password string `json:"password,omitempty"`
+	// Name of the secret key that contains bitcoin node RPC API username
+	ApiUserSecretKey string `json:"apiUserSecretKey,omitempty"`
+
+	// Name of the secret key that contains bitcoin node RPC API password
+	ApiPasswordSecretKey string `json:"apiPasswordSecretKey,omitempty"`
 }
 
 type WalletPassword struct {

--- a/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
+++ b/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
@@ -125,16 +125,21 @@ spec:
               rpcServer:
                 description: Configuration for the RPC Server
                 properties:
+                  apiAuthSecretName:
+                    description: Name of the secret that contains RPC API credentials
+                    type: string
+                  apiPasswordSecretKey:
+                    description: Name of the secret key that contains RPC API password
+                    type: string
+                  apiUserSecretKey:
+                    description: Name of the secret key that contains RPC API username
+                    type: string
                   certSecret:
                     description: Name of the secret that contains TLS certificates
                       for the RPC server
                     type: string
-                  password:
-                    description: Password to authenticate to the RPC server
-                    type: string
-                  user:
-                    description: Username to authenticate to the RPC server
-                    type: string
+                required:
+                - apiAuthSecretName
                 type: object
             type: object
           status:

--- a/config/crd/bases/bitcoin.kiln-fired.github.io_lightningnodes.yaml
+++ b/config/crd/bases/bitcoin.kiln-fired.github.io_lightningnodes.yaml
@@ -38,6 +38,18 @@ spec:
               bitcoinConnection:
                 description: Configuration for the Bitcoin RPC client
                 properties:
+                  apiAuthSecretName:
+                    description: Name of the secret that contains bitcoin node RPC
+                      API credentials
+                    type: string
+                  apiPasswordSecretKey:
+                    description: Name of the secret key that contains bitcoin node
+                      RPC API password
+                    type: string
+                  apiUserSecretKey:
+                    description: Name of the secret key that contains bitcoin node
+                      RPC API username
+                    type: string
                   certSecret:
                     description: Name of the secret that contains TLS certificates
                       for the RPC server
@@ -50,13 +62,8 @@ spec:
                     description: Bitcoin network, e.g. simnet, testnet, regressionnet,
                       mainnet
                     type: string
-                  password:
-                    description: Password to authenticate to the RPC server
-                    type: string
-                  user:
-                    description: Username to authenticate to the RPC server
-                    type: string
                 required:
+                - apiAuthSecretName
                 - host
                 - network
                 type: object

--- a/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
+++ b/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
@@ -11,5 +11,6 @@ spec:
     secondsPerBlock: 10
   rpcServer:
     certSecret: btcd-rpc-tls
-    user: node-user
-    password: st4cks4ts
+    apiAuthSecretName: btcd-rpc-creds
+    apiUserSecretKey: username
+    apiPasswordSecretKey: password

--- a/config/samples/bitcoin_v1alpha1_lightningnode.yaml
+++ b/config/samples/bitcoin_v1alpha1_lightningnode.yaml
@@ -7,8 +7,9 @@ spec:
     host: btcd
     network: simnet
     certSecret: btcd-rpc-tls
-    user: node-user
-    password: st4cks4ts
+    apiAuthSecretName: btcd-rpc-creds
+    apiUserSecretKey: username
+    apiPasswordSecretKey: password
   wallet:
     password:
       secretName: alice-wallet


### PR DESCRIPTION
Convert RPC credentials to secret references for:
- Bitcoin client built into the controller
- Bitcoin node StatefulSet
- Lightning node StatefulSet