### PR TITLE
make block timer optional

### DIFF
--- a/api/v1alpha1/bitcoinnode_types.go
+++ b/api/v1alpha1/bitcoinnode_types.go
@@ -70,9 +70,14 @@ type Mining struct {
 	// +kubebuilder:default:=0
 	MinBlocks int64 `json:"minBlocks,omitempty"`
 
+	// Mine new blocks periodically
+	// +optional
+	// +kubebuilder:default:=false
+	PeriodicBlocksEnabled bool `json:"periodicBlocksEnabled,omitempty"`
+
 	// Number of seconds to wait between scheduled block generation
 	// +optional
-	// +kubebuilder:default:=0
+	// +kubebuilder:default:=30
 	SecondsPerBlock int64 `json:"secondsPerBlock,omitempty"`
 }
 

--- a/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
+++ b/config/crd/bases/bitcoin.kiln-fired.github.io_bitcoinnodes.yaml
@@ -61,6 +61,10 @@ spec:
                     description: Minimum number of blocks to mine on initial startup
                     format: int64
                     type: integer
+                  periodicBlocksEnabled:
+                    default: false
+                    description: Mine new blocks periodically
+                    type: boolean
                   rewardAddress:
                     description: Address the should receive block rewards
                     properties:
@@ -74,7 +78,7 @@ spec:
                         type: string
                     type: object
                   secondsPerBlock:
-                    default: 0
+                    default: 30
                     description: Number of seconds to wait between scheduled block
                       generation
                     format: int64

--- a/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
+++ b/config/samples/bitcoin_v1alpha1_bitcoinnode.yaml
@@ -9,6 +9,7 @@ spec:
       secretName: mining-reward-wallet
       secretKey: np2wkhAddress
     minBlocks: 400
+    periodicBlocksEnabled: true
     secondsPerBlock: 10
   rpcServer:
     certSecret: btcd-rpc-tls

--- a/controllers/bitcoinnode_controller_test.go
+++ b/controllers/bitcoinnode_controller_test.go
@@ -62,8 +62,9 @@ var _ = Describe("BitcoinNode controller", func() {
 					RewardAddress: bitcoinv1alpha1.RewardAddress{
 						SecretName: "seed",
 					},
-					MinBlocks:       400,
-					SecondsPerBlock: 10,
+					MinBlocks:             400,
+					PeriodicBlocksEnabled: true,
+					SecondsPerBlock:       10,
 				},
 				RPCServer: bitcoinv1alpha1.RPCServer{
 					CertSecret:           "btcd-rpc-tls",
@@ -149,6 +150,12 @@ var _ = Describe("BitcoinNode controller", func() {
 			}
 			Expect(rpcUserEnvExists).To(BeTrue())
 			Expect(rpcPassEnvExists).To(BeTrue())
+			return nil
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("checking for the existence of a timer container")
+		Eventually(func() error {
+			Expect(len(foundStatefulSet.Spec.Template.Spec.Containers)).To(Equal(2))
 			return nil
 		}, time.Minute, time.Second).Should(Succeed())
 	})


### PR DESCRIPTION
Avoid deploying a container to periodically issue block generation commands if the feature is not used in a BitcoinNode deployment.